### PR TITLE
Release V1.0.0: Initial deployment of synchronizer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notion-sync"
-version = "0.1.0"
+version = "1.0.0"
 description = "A Python project for syncing tasks between Notion and Google Tasks."
 authors = ["Your Name <your.email@example.com>"]
 license = "MIT"


### PR DESCRIPTION
This pull request includes a version update for the notion-sync project. The change updates the version number from 0.1.0 to 1.0.0 in the pyproject.toml file. This update is to correct a previous pull request where the bump versioning did not work as expected.

Changes:
[pyproject.toml](https://github.com/MarcChen/Notion2GoogleTasks/compare/main...dev/deploy-services-to-github-action): Updated the project version from 0.1.0 to 1.0.0.