### PR TITLE
fix : still trying to fix bump version expansion issue

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           pr_title="${{ github.event.pull_request.title }}"
           pr_body="${{ github.event.pull_request.body }}"
-          pr_body=$(echo "$pr_body" | sed  -e 's/`//g')
+          pr_body="${pr_body//\`/}"
           pr_author="${{ github.event.pull_request.user.login }}"
           pr_number="${{ github.event.pull_request.number }}"
           date=$(date '+%Y-%m-%d')


### PR DESCRIPTION
Bash is interpreting your multi-line PR body as code due to unescaped backticks, the solution is to escaped backtick


For instance, with previous PR, this was the reason it failed : 

> ### Environment Variables Cleanup:
>   * [`.env_template`](diffhunk://#diff-83053cdd58e4c1fa71b292dfec284[6](https://github.com/MarcChen/Notion2GoogleTasks/actions/runs/12455742423/job/34769019982#step:6:6)007b3cbabe2c9253a530466441d9f5c2feL17-L20): Removed optional variables `FREE_MOBILE_PASS` and `FREE_MOBILE_USER`.