### PR TITLE
fix previous MR, content between backticks was removed

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -69,10 +69,9 @@ jobs:
         run: |
           set -e
           echo "${{ github.event.pull_request.body }}" > pr_body_raw.txt
-          sed -E -i 's/```([^`]+)```/\1/g' pr_body_raw.txt
-          sed -E -i 's/`([^`]+)`/\1/g' pr_body_raw.txt
+          perl -0777 -pe 's/```(.*?)```/$1/gs' pr_body_raw.txt > tmp && mv tmp pr_body_raw.txt
+          perl -0777 -pe 's/`(.*?)`/$1/gs' pr_body_raw.txt > tmp && mv tmp pr_body_raw.txt
           pr_body="$(cat pr_body_raw.txt)"
-
           pr_title="${{ github.event.pull_request.title }}"
           pr_author="${{ github.event.pull_request.user.login }}"
           pr_number="${{ github.event.pull_request.number }}"


### PR DESCRIPTION
Still testing with the following PR body content

> ### Environment Variables Cleanup:
>   * [`.env_template`](diffhunk://#diff-83053cdd58e4c1fa71b292dfec284[6](https://github.com/MarcChen/Notion2GoogleTasks/actions/runs/12455742423/job/34769019982#step:6:6)007b3cbabe2c9253a530466441d9f5c2feL17-L20): Removed optional variables `FREE_MOBILE_PASS` and `FREE_MOBILE_USER`.