### PR TITLE
fix : due date not matching

### DIFF
--- a/services/sync_notion_google_task/main.py
+++ b/services/sync_notion_google_task/main.py
@@ -35,7 +35,12 @@ class NotionToGoogleTaskSyncer:
                 page_id = page['unique_id']
                 page_title = page['title']
                 tag = page['tags'] or "NoTag"
-                due_date = self.compute_due_date(page['due_date'])
+                due_date = page['due_date']
+
+                # Adjust the due date to today if it's too far in the future.
+                # This is a personal preference to ensure tasks are dealt with promptly.
+                recomputed_due_date = self.compute_due_date(page['due_date']) 
+                
                 importance = page['importance']
                 text = page['text']
                 urls = page['url']
@@ -69,7 +74,7 @@ class NotionToGoogleTaskSyncer:
                         tasklist_id=tasklist_id,
                         task_title=f"{page_title} - {parent_page_name} | ({page_id})",
                         task_notes=task_description,
-                        due_date=due_date
+                        due_date=recomputed_due_date
                     )
                     console.print(f"[green]Task for page '{page_title}' created successfully![/green]")
                 except Exception as e:


### PR DESCRIPTION
The due date in the description doesn't align with the one in Notion. This discrepancy arises because I use an offset system: if the due date in Notion is too far in the future, I prefer to set the task date to today. To manage this, I maintain a secondary date specifically for setting the task date

---
# Copilot Genreated Summary 

This pull request includes several changes to the `sync_notion_google_task` service and its integration tests. The most important changes include adjustments to the due date handling in the synchronization method, updates to the integration test setup, and improvements to the validation logic.

### Changes in `sync_notion_google_task` service:

* Adjusted the due date handling in `sync_pages_to_google_tasks` method by introducing `recomputed_due_date` to ensure tasks are dealt with promptly. (`services/sync_notion_google_task/main.py`) [[1]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2L38-R43) [[2]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2L72-R77)

### Changes in integration tests:

* Improved the validation logic in the integration test to fetch and parse Notion pages and validate synchronization with Google Tasks. (`tests/integration/test_notion_to_google_syncer_integration.py`)