### PR TITLE
fix : patch due_date type error

### DIFF
--- a/services/sync_notion_google_task/main.py
+++ b/services/sync_notion_google_task/main.py
@@ -118,7 +118,7 @@ class NotionToGoogleTaskSyncer:
 
         return google_task_lists[tag]
 
-    def build_task_description(self, importance: Optional[str], text: Optional[str], urls: Optional[List[str]], due_date: Optional[datetime]) -> str:
+    def build_task_description(self, importance: Optional[str], text: Optional[str], urls: Optional[List[str]], due_date: Optional[str]) -> str:
         """
         Builds a task description from the given properties.
 
@@ -141,6 +141,7 @@ class NotionToGoogleTaskSyncer:
             for url in urls:
                 description_lines.append(f" - {url}")
         if due_date:
+            due_date = datetime.fromisoformat(due_date)
             description_lines.append(f"Due Date: {due_date.strftime('%d-%m-%y')}")
         return "\n".join(description_lines)
 

--- a/tests/unit/test_notion_to_google_syncer.py
+++ b/tests/unit/test_notion_to_google_syncer.py
@@ -22,7 +22,7 @@ def test_build_task_description(mock_syncer):
     importance = "High"
     text = "Complete the report"
     urls = ["http://example.com", "http://example.org"]
-    due_date = datetime.utcnow()
+    due_date = (datetime.utcnow() + timedelta(days=7)).isoformat()  # Adjusted to a string type
     
     description = syncer.build_task_description(importance, text, urls, due_date)
     
@@ -31,7 +31,7 @@ def test_build_task_description(mock_syncer):
     assert "Links:" in description
     assert " - http://example.com" in description
     assert " - http://example.org" in description
-    assert f"Due Date: {due_date.strftime('%d-%m-%y')}" in description
+    assert f"Due Date: {datetime.fromisoformat(due_date).strftime('%d-%m-%y')}" in description
 
     # Test case: Missing fields
     description = syncer.build_task_description(None, None, None, None)
@@ -50,11 +50,11 @@ def test_build_task_description(mock_syncer):
 
 def test_compute_due_date(mock_syncer):
     syncer, _, _ = mock_syncer
-    
+
     # Test case: due_date is None
     due_date = syncer.compute_due_date(None)
     assert due_date.date() == datetime.utcnow().date()
-    
+
     # Test case: due_date exceeds 14 days
     future_date = (datetime.utcnow() + timedelta(days=20)).isoformat()
     adjusted_date = syncer.compute_due_date(future_date)


### PR DESCRIPTION
Patch to fix this issue : 

> Processing Page: licence FFA 2024/2025 ou ton attestation PPS - SEMI  (ID: 597)
>   Task List ID for tag 'Travail': c0RkZFdiSm9NQnJ0c2d0aA
> Error building task description: 'str' object has no attribute 'strftime'

This pull request includes changes to the `services/sync_notion_google_task` service and its corresponding unit tests to handle due dates as strings instead of `datetime` objects. The most important changes are the modification of the `build_task_description` method and the corresponding updates to the unit tests.

Changes to due date handling:

* [`services/sync_notion_google_task/main.py`](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2L121-R121): Modified the `build_task_description` method to accept `due_date` as a string and convert it to a `datetime` object within the method. [[1]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2L121-R121) [[2]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2R144)

Updates to unit tests:

* [`tests/unit/test_notion_to_google_syncer.py`](diffhunk://#diff-ae32bc452849d064a1b9c50ca3ab1c54dffd8610b3b2b610dc56ab68c9497f6aL25-R25): Adjusted the `due_date` parameter to be a string in the `test_build_task_description` method and updated assertions to reflect this change. [[1]](diffhunk://#diff-ae32bc452849d064a1b9c50ca3ab1c54dffd8610b3b2b610dc56ab68c9497f6aL25-R25) [[2]](diffhunk://#diff-ae32bc452849d064a1b9c50ca3ab1c54dffd8610b3b2b610dc56ab68c9497f6aL34-R34)