### PR TITLE
fix : duplicated created tasks 

### DIFF
--- a/services/notion/src/notion_client.py
+++ b/services/notion/src/notion_client.py
@@ -169,15 +169,17 @@ class NotionClient:
             print(f"[red]Error marking task {task_id} as 'Done': {e}[/red]")
             return None
 
-    def create_new_page(self, title: str) -> Optional[str]:
+    def create_new_page(self, title: str, from_task: bool = False) -> Optional[str]:
         """
-        Create a new page in the Notion database with the "Today" checkbox set to True.
-
+        Create a new page in the Notion database.
+        If from_task is True, sets the FromTask checkbox to True.
+        
         Args:
             title (str): The title of the new page.
-
+            from_task (bool): Flag to indicate this page comes from a task.
+        
         Returns:
-            Optional[str]: The ID of the newly created page if successful; None otherwise.
+            Optional[str]: The unique page ID if successful; None otherwise.
         """
         url = "https://api.notion.com/v1/pages"
         payload = {
@@ -185,6 +187,7 @@ class NotionClient:
             "properties": {
                 "Name": {"title": [{"text": {"content": title}}]},
                 "Today": {"checkbox": True},
+                "FromTask": {"checkbox": from_task},
             },
         }
 
@@ -192,7 +195,7 @@ class NotionClient:
             response = requests.post(url, headers=self.headers, json=payload)
             response.raise_for_status()
             print(
-                f"[green]Page with ID '{response.json().get('ID', 'N/A')}' created successfully with 'Today' checkbox set to True![/green]"
+                f"[green]Page with ID '{response.json().get('ID', 'N/A')}' created successfully with 'FromTask' set to {from_task}![/green]"
             )
             return (
                 response.json()
@@ -352,6 +355,8 @@ class NotionClient:
                     .get("unique_id", {})
                     .get("number", None)
                 )
+                # Extract "FromTask" checkbox from properties.
+                from_task = properties.get("FromTask", {}).get("checkbox", False)
 
                 parsed_data.append(
                     {
@@ -370,6 +375,7 @@ class NotionClient:
                         "text": text_property,
                         "url": links,
                         "parent_page_id": parent_page_id,
+                        "FromTask": from_task,
                     }
                 )
 

--- a/services/sync_notion_google_task/main.py
+++ b/services/sync_notion_google_task/main.py
@@ -68,9 +68,10 @@ class NotionToGoogleTaskSyncer:
                     f"[bold]Processing Page ID: {page_id}[/bold]"
                 )
 
-                if self.task_exists(google_task_lists, page_id):
+                # Modify check: also skip if the Notion page has the FromTask checkbox enabled
+                if self.task_exists(google_task_lists, page_id) or page.get("FromTask", False):
                     console.print(
-                        f"[yellow]Task for page ID '{page_id}' already exists. Skipping...[/yellow]"
+                        f"[yellow]Task for page ID '{page_id}' already exists or FromTask enabled. Skipping...[/yellow]"
                     )
                     progress.advance(task)
                     continue
@@ -298,8 +299,9 @@ class NotionToGoogleTaskSyncer:
                                 )
                             continue
 
+                        # Create new Notion page with FromTask checkbox = True
                         notion_page_id = self.notion_client.create_new_page(
-                            task_title
+                            task_title, from_task=True
                         )
                         updated_title = f"{task_title} | ({notion_page_id})"
                         self.google_tasks_manager.modify_task_title(


### PR DESCRIPTION
### Fix: Duplicated Created Tasks

This pull request addresses an issue where tasks were being duplicated during synchronization between Notion and Google Tasks. The fix introduces a new mechanism to mark pages that originate from tasks by adding a `FromTask` checkbox property in Notion. This property helps prevent redundant task creation during sync operations.

#### Key Changes:

- **Notion Client Updates:**
  - **`create_new_page` Method:**  
    An optional `from_task` parameter has been added to set the `FromTask` checkbox when creating a new page in Notion.
  - **`parse_notion_response` Method:**  
    Updated to extract the `FromTask` checkbox value from Notion’s response, ensuring that the task origin is correctly tracked in the parsed data.

- **Synchronization Logic Updates:**
  - **`sync_pages_to_google_tasks` Method:**  
    Modified to skip pages where the `FromTask` checkbox is enabled, preventing the creation of duplicate tasks during synchronization.
  - **`print_progress` Method:**  
    Now creates new Notion pages with the `FromTask` checkbox set to `True` when tasks are being synchronized from Google Tasks, ensuring the origin is properly flagged.

This fix ensures that tasks originating from Google Tasks are not re-created in Notion during subsequent syncs, effectively eliminating the duplication issue.
