### PR TITLE
fix datetime type issue

### DIFF
--- a/services/sync_notion_google_task/main.py
+++ b/services/sync_notion_google_task/main.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Dict, List, Optional
+import datetime as dt
 
 from rich import print
 from rich.console import Console
@@ -196,15 +197,17 @@ class NotionToGoogleTaskSyncer:
         Returns:
             datetime: The adjusted due date as a `datetime` object.
         """
-        today = datetime.utcnow()
+        today = datetime.now(dt.timezone.utc)
 
         if due_date_str:
             due_date = datetime.fromisoformat(due_date_str)
+            if due_date.tzinfo is None:
+                due_date = due_date.replace(tzinfo=dt.timezone.utc)
         else:
-            due_date = today  # Default to today if no due date is provided
+            due_date = today
 
         # Adjust the due date if it's more than 14 days from today
-        if (due_date - today).days > 14:
+        if (due_date - today).days > 21:
             due_date = today
 
         return due_date
@@ -268,8 +271,6 @@ class NotionToGoogleTaskSyncer:
                         potential_notion_id = self.extract_page_id_from_task_title(
                             task_title
                         )
-
-                        print(f"Task due {task_due}")
 
                         if potential_notion_id:
                             if is_completed:

--- a/services/sync_notion_google_task/main.py
+++ b/services/sync_notion_google_task/main.py
@@ -200,13 +200,13 @@ class NotionToGoogleTaskSyncer:
         today = datetime.now(dt.timezone.utc)
 
         if due_date_str:
-            due_date = datetime.fromisoformat(due_date_str)
+            due_date = dt.datetime.fromisoformat(due_date_str)
             if due_date.tzinfo is None:
                 due_date = due_date.replace(tzinfo=dt.timezone.utc)
         else:
             due_date = today
 
-        # Adjust the due date if it's more than 14 days from today
+        # Adjust the due date if it's more than 21 days from today
         if (due_date - today).days > 21:
             due_date = today
 

--- a/tests/unit/test_notion_to_google_syncer.py
+++ b/tests/unit/test_notion_to_google_syncer.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import datetime as dt
 from unittest.mock import patch
 
 import pytest
@@ -77,39 +78,36 @@ def test_build_task_description(mock_syncer):
 def test_compute_due_date(mock_syncer):
     syncer, _, _ = mock_syncer
 
+    now_utc = datetime.now(dt.timezone.utc)
+
     # Test case: due_date is None
     due_date = syncer.compute_due_date(None)
-    assert due_date.date() == datetime.utcnow().date()
+    assert due_date.date() == now_utc.date()
 
-    # Test case: due_date exceeds 14 days
-    future_date = (datetime.utcnow() + timedelta(days=20)).isoformat()
+    # Test case: due_date exceeds 21 days
+    future_date = (now_utc + timedelta(days=30)).isoformat()
     adjusted_date = syncer.compute_due_date(future_date)
-    assert adjusted_date.date() == datetime.utcnow().date()
+    assert adjusted_date.date() == now_utc.date()
 
-    # Test case: due_date within 14 days
-    valid_date = (datetime.utcnow() + timedelta(days=10)).isoformat()
+    # Test case: due_date within 21 days
+    valid_date = (now_utc + timedelta(days=10)).isoformat()
     computed_date = syncer.compute_due_date(valid_date)
-    assert (
-        computed_date.date() == (datetime.utcnow() + timedelta(days=10)).date()
-    )
+    assert computed_date.date() == (now_utc + timedelta(days=10)).date()
 
     # Test case: Invalid date string
     with pytest.raises(ValueError):
         syncer.compute_due_date("invalid-date")
 
     # Test case: Past date
-    past_date = (datetime.utcnow() - timedelta(days=5)).isoformat()
+    past_date = (now_utc - timedelta(days=5)).isoformat()
     computed_date = syncer.compute_due_date(past_date)
-    assert (
-        computed_date.date() == (datetime.utcnow() - timedelta(days=5)).date()
-    )
+    assert computed_date.date() == (now_utc - timedelta(days=5)).date()
 
-    # Test case: Exact 14 days
-    exact_14_days = (datetime.utcnow() + timedelta(days=14)).isoformat()
-    computed_date = syncer.compute_due_date(exact_14_days)
-    assert (
-        computed_date.date() == (datetime.utcnow() + timedelta(days=14)).date()
-    )
+    # Test case: Exact 21 days
+    exact_21_days = (now_utc + timedelta(days=21)).isoformat()
+    computed_date = syncer.compute_due_date(exact_21_days)
+    assert computed_date.date() == (now_utc + timedelta(days=21)).date()
+
 
 
 def test_task_exists(mock_syncer):


### PR DESCRIPTION
This pull request includes several changes to the `services/sync_notion_google_task/main.py` file, focusing on improving date handling and cleaning up the code. The most important changes are listed below:

Improvements to date handling:

* [`services/sync_notion_google_task/main.py`](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2R3): Imported `datetime` as `dt` to avoid naming conflicts and improve code readability.
* [`services/sync_notion_google_task/main.py`](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2L199-R210): Changed `datetime.utcnow()` to `datetime.now(dt.timezone.utc)` to ensure the use of timezone-aware datetime objects.
* [`services/sync_notion_google_task/main.py`](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2L199-R210): Added logic to set the timezone to UTC if the `due_date` is naive (i.e., lacks timezone information).
* [`services/sync_notion_google_task/main.py`](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2L199-R210): Adjusted the due date threshold from 14 days to 21 days to provide more flexibility.

Code cleanup:

* [`services/sync_notion_google_task/main.py`](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2L272-L273): Removed an unnecessary print statement that displayed the task due date.