### PR TITLE
feature : adding notion url page to task if existing

### DIFF
--- a/services/sync_notion_google_task/main.py
+++ b/services/sync_notion_google_task/main.py
@@ -170,6 +170,7 @@ class NotionToGoogleTaskSyncer:
             importance (Optional[str]): The importance level of the task.
             text (Optional[str]): The text content from the Notion page.
             urls (Optional[List[str]]): A list of URLs from the Notion page.
+            page_url (Optional[List[str]]): Notion page URL.
             due_date (Optional[str]): The due date of the task.
 
         Returns:

--- a/services/sync_notion_google_task/main.py
+++ b/services/sync_notion_google_task/main.py
@@ -59,6 +59,7 @@ class NotionToGoogleTaskSyncer:
                 importance = page["importance"]
                 text = page["text"]
                 urls = page["url"]
+                page_url = page["page_url"]
                 parent_page_name = page["parent_page_name"] or None
 
                 console.print(f"[bold]Processing Page ID: {page_id}[/bold]")
@@ -159,6 +160,7 @@ class NotionToGoogleTaskSyncer:
         importance: Optional[str],
         text: Optional[str],
         urls: Optional[List[str]],
+        page_url: Optional[str],
         due_date: Optional[str],
     ) -> str:
         """
@@ -182,6 +184,8 @@ class NotionToGoogleTaskSyncer:
             description_lines.append("Links:")
             for url in urls:
                 description_lines.append(f" - {url}")
+        if page_url:
+            description_lines.append(f"Page URL: {page_url}")
         if due_date:
             due_date = datetime.fromisoformat(due_date)
             description_lines.append(f"Due Date: {due_date.strftime('%d-%m-%y')}")

--- a/services/sync_notion_google_task/main.py
+++ b/services/sync_notion_google_task/main.py
@@ -88,7 +88,7 @@ class NotionToGoogleTaskSyncer:
 
                 try:
                     task_description = self.build_task_description(
-                        importance, text, urls, due_date
+                        importance, text, urls, page_url, due_date
                     )
                 except Exception as e:
                     console.print(f"[red]Error building task description: {e}[/red]")
@@ -177,6 +177,8 @@ class NotionToGoogleTaskSyncer:
             str: The task description.
         """
         description_lines = []
+        if page_url:
+            description_lines.append(f"Page URL: {page_url}")
         if importance:
             description_lines.append(f"Importance: {importance}")
         if text:
@@ -185,8 +187,6 @@ class NotionToGoogleTaskSyncer:
             description_lines.append("Links:")
             for url in urls:
                 description_lines.append(f" - {url}")
-        if page_url:
-            description_lines.append(f"Page URL: {page_url}")
         if due_date:
             due_date = datetime.fromisoformat(due_date)
             description_lines.append(f"Due Date: {due_date.strftime('%d-%m-%y')}")

--- a/tests/unit/test_notion_to_google_syncer.py
+++ b/tests/unit/test_notion_to_google_syncer.py
@@ -37,31 +37,32 @@ def test_build_task_description(mock_syncer):
     importance = "High"
     text = "Complete the report"
     urls = ["http://example.com", "http://example.org"]
+    page_url = "http://example.com/page"
     due_date = (
         datetime.utcnow() + timedelta(days=7)
-    ).isoformat()  # Adjusted to a string type
+    ).isoformat()
 
     description = syncer.build_task_description(
-        importance, text, urls, due_date
+        importance, text, urls, page_url, due_date
     )
 
     assert "Importance: High" in description
     assert "Details: Complete the report" in description
     assert "Links:" in description
     assert " - http://example.com" in description
-    assert " - http://example.org" in description
+    assert "Page URL: http://example.com/page" in description 
     assert (
         f"Due Date: {datetime.fromisoformat(due_date).strftime('%d-%m-%y')}"
         in description
     )
 
     # Test case: Missing fields
-    description = syncer.build_task_description(None, None, None, None)
+    description = syncer.build_task_description(None, None, None, None, None)
     assert description == ""  # Should handle missing data gracefully
 
     # Test case: Empty URLs list
     description = syncer.build_task_description(
-        "Medium", "Some text", [], due_date
+        "Medium", "Some text", [], page_url, due_date
     )
     assert "Importance: Medium" in description
     assert "Details: Some text" in description
@@ -70,7 +71,7 @@ def test_build_task_description(mock_syncer):
     # Test case: Very long text
     long_text = "A" * 1000  # Simulating a very long task description
     description = syncer.build_task_description(
-        "Low", long_text, urls, due_date
+        "Low", long_text, urls, page_url, due_date
     )
     assert long_text in description  # Ensure the full text is included
 


### PR DESCRIPTION
This pull request includes changes to the `services/sync_notion_google_task/main.py` file to enhance the synchronization of pages to Google Tasks. The most important changes include adding a new field `page_url` to the task description and ensuring it is processed correctly.

Enhancements to task synchronization:

* [`services/sync_notion_google_task/main.py`](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2R62): Added the `page_url` field to the `sync_pages_to_google_tasks` method to capture the URL of the page being processed.
* [`services/sync_notion_google_task/main.py`](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2R163): Updated the `build_task_description` method to include the `page_url` parameter in the task description. [[1]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2R163) [[2]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2R187-R188)