### PR TITLE
adjusted recompute due date (treshold from 21 to 365)

### DIFF
--- a/services/sync_notion_google_task/main.py
+++ b/services/sync_notion_google_task/main.py
@@ -194,7 +194,7 @@ class NotionToGoogleTaskSyncer:
 
     def compute_due_date(self, due_date_str: Optional[str]) -> datetime:
         """
-        Computes the due date, adjusting it to today if the difference exceeds 14 days.
+        Computes the due date, adjusting it to today if the difference exceeds 1 year.
 
         Args:
             due_date_str (Optional[str]): The due date as a string in ISO format, or None.
@@ -205,17 +205,20 @@ class NotionToGoogleTaskSyncer:
         today = datetime.now(dt.timezone.utc)
 
         if due_date_str:
-            due_date = dt.datetime.fromisoformat(due_date_str)
+            due_date = datetime.fromisoformat(due_date_str)
             if due_date.tzinfo is None:
                 due_date = due_date.replace(tzinfo=dt.timezone.utc)
+            
+            # Calculate the difference in days
+            days_difference = (due_date - today).days
+            
+            # Adjust the due date if it's more than 365 days from today
+            if days_difference >= 365:
+                return today
+            else:
+                return due_date
         else:
-            due_date = today
-
-        # Adjust the due date if it's more than 21 days from today
-        if (due_date - today).days > 21:
-            due_date = today
-
-        return due_date
+            return today
 
     def extract_page_id_from_task_title(self, task_title: str) -> Optional[int]:
         """

--- a/services/sync_notion_google_task/main.py
+++ b/services/sync_notion_google_task/main.py
@@ -213,7 +213,7 @@ class NotionToGoogleTaskSyncer:
             days_difference = (due_date - today).days
             
             # Adjust the due date if it's more than 365 days from today
-            if days_difference >= 365:
+            if days_difference > 365:
                 return today
             else:
                 return due_date

--- a/tests/unit/test_notion_to_google_syncer.py
+++ b/tests/unit/test_notion_to_google_syncer.py
@@ -86,7 +86,7 @@ def test_compute_due_date(mock_syncer):
     assert due_date.date() == now_utc.date()
 
     # Test case: due_date exceeds 1 year
-    future_date = (now_utc + timedelta(days=366)).isoformat()
+    future_date = (now_utc + timedelta(days=367)).isoformat()
     adjusted_date = syncer.compute_due_date(future_date)
     assert adjusted_date.date() == now_utc.date()
 

--- a/tests/unit/test_notion_to_google_syncer.py
+++ b/tests/unit/test_notion_to_google_syncer.py
@@ -50,7 +50,7 @@ def test_build_task_description(mock_syncer):
     assert "Details: Complete the report" in description
     assert "Links:" in description
     assert " - http://example.com" in description
-    assert "Page URL: http://example.com/page" in description 
+    assert "Page URL: http://example.com/page" in description
     assert (
         f"Due Date: {datetime.fromisoformat(due_date).strftime('%d-%m-%y')}"
         in description
@@ -85,15 +85,15 @@ def test_compute_due_date(mock_syncer):
     due_date = syncer.compute_due_date(None)
     assert due_date.date() == now_utc.date()
 
-    # Test case: due_date exceeds 21 days
-    future_date = (now_utc + timedelta(days=30)).isoformat()
+    # Test case: due_date exceeds 1 year
+    future_date = (now_utc + timedelta(days=366)).isoformat()
     adjusted_date = syncer.compute_due_date(future_date)
     assert adjusted_date.date() == now_utc.date()
 
-    # Test case: due_date within 21 days
-    valid_date = (now_utc + timedelta(days=10)).isoformat()
+    # Test case: due_date within 1 year
+    valid_date = (now_utc + timedelta(days=300)).isoformat()
     computed_date = syncer.compute_due_date(valid_date)
-    assert computed_date.date() == (now_utc + timedelta(days=10)).date()
+    assert computed_date.date() == (now_utc + timedelta(days=300)).date()
 
     # Test case: Invalid date string
     with pytest.raises(ValueError):
@@ -104,11 +104,15 @@ def test_compute_due_date(mock_syncer):
     computed_date = syncer.compute_due_date(past_date)
     assert computed_date.date() == (now_utc - timedelta(days=5)).date()
 
-    # Test case: Exact 21 days
-    exact_21_days = (now_utc + timedelta(days=21)).isoformat()
-    computed_date = syncer.compute_due_date(exact_21_days)
-    assert computed_date.date() == (now_utc + timedelta(days=21)).date()
+    # Test case: Exact 1 year
+    exact_365_days = (now_utc + timedelta(days=365)).isoformat()
+    computed_date = syncer.compute_due_date(exact_365_days)
+    assert computed_date.date() == (now_utc + timedelta(days=365)).date()
 
+    # Test case: Date without timezone
+    naive_date = datetime.now() + timedelta(days=10)
+    computed_date = syncer.compute_due_date(naive_date.isoformat())
+    assert computed_date.date() == naive_date.date()
 
 
 def test_task_exists(mock_syncer):


### PR DESCRIPTION
This pull request includes changes to the `compute_due_date` method in `services/sync_notion_google_task/main.py` and its corresponding unit tests in `tests/unit/test_notion_to_google_syncer.py`. The primary change is adjusting the due date threshold from 21 days to 1 year.

Changes to the `compute_due_date` method:

* Updated the due date adjustment logic to set the due date to today if it exceeds 1 year instead of 21 days. [[1]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2L197-R197) [[2]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2L208-R221)

Updates to unit tests:

* Modified test cases to reflect the new 1-year threshold for due date adjustments. [[1]](diffhunk://#diff-ae32bc452849d064a1b9c50ca3ab1c54dffd8610b3b2b610dc56ab68c9497f6aL88-R96) [[2]](diffhunk://#diff-ae32bc452849d064a1b9c50ca3ab1c54dffd8610b3b2b610dc56ab68c9497f6aL107-R115)
* Added a new test case to handle dates without timezone information.