### PR TITLE
Add last-edited filtering for Notion pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ For detailed steps, refer to the [Quickstart Guide](./Quickstart.md).
 - **Google API**:
     - OAuth2 client configuration
     - Access token retrieval
+- **Environment Variable**:
+    - `LAST_SUCCESSFUL_SYNC` ISO timestamp to filter pages by last edit
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -78,3 +78,13 @@ For detailed steps, refer to the [Quickstart Guide](./Quickstart.md).
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request.
+
+## Sync Overview Diagram
+
+```mermaid
+flowchart TD
+    A[Notion Database] -- Updates --> B(Sync Engine)
+    B -- Creates/Updates --> C[Google Tasks]
+    C -- Completed Tasks --> B
+    B -- Mark Done --> A
+```

--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
         sms_user=free_mobile_user_id,
         sms_password=free_mobile_api_key,
     )
-    syncer.sync_pages_to_google_tasks()
+    syncer.sync_pages_to_google_tasks(last_successful_sync)
     syncer.sync_google_tasks_to_notion(
         last_successful_sync=last_successful_sync
     )

--- a/services/notion/src/notion_client.py
+++ b/services/notion/src/notion_client.py
@@ -65,14 +65,16 @@ class NotionClient:
             if last_edited_since is not None:
                 last_edit_filter = {
                     "timestamp": "last_edited_time",
-                    "last_edited_time": {"on_or_after": last_edited_since.isoformat()},
+                    "last_edited_time": {
+                        "on_or_after": last_edited_since.isoformat()
+                    },
                 }
                 if "filter" in query_payload:
                     query_payload["filter"] = {
                         "and": [query_payload["filter"], last_edit_filter]
                     }
                 else:
-                    query_payload["filter"] = last_edit_filter
+                    query_payload["filter"] = {"and": [last_edit_filter]}
 
             response = requests.post(url, headers=self.headers, json=query_payload)
             response.raise_for_status()

--- a/services/sync_notion_google_task/main.py
+++ b/services/sync_notion_google_task/main.py
@@ -28,11 +28,14 @@ class NotionToGoogleTaskSyncer:
 
     # Method to sync Notion pages to Google Tasks
 
-    def sync_pages_to_google_tasks(self):
+    def sync_pages_to_google_tasks(self, last_successful_sync: datetime):
         """
         Synchronizes Notion pages to Google Tasks with a progress bar that remains at the top.
+        Only pages edited since ``last_successful_sync`` are processed.
         """
-        notion_pages = self.notion_client.get_filtered_sorted_database()
+        notion_pages = self.notion_client.get_filtered_sorted_database(
+            last_edited_since=last_successful_sync
+        )
         if not notion_pages:
             print("[red]No pages retrieved from Notion.[/red]")
             return

--- a/tests/unit/test_notion_client.py
+++ b/tests/unit/test_notion_client.py
@@ -76,7 +76,9 @@ class TestNotionClient:
         sent_payload = mock_post.call_args.kwargs["json"]
         assert "filter" in sent_payload
         assert any(
-            f.get("timestamp") == "last_edited_time" for f in sent_payload["filter"]["and"]
+            f.get("timestamp") == "last_edited_time" and
+            f.get("last_edited_time", {}).get("on_or_after") == ts.isoformat()
+            for f in sent_payload["filter"]["and"]
         )
 
     @patch("requests.get")


### PR DESCRIPTION
## Summary
- filter pages by `last_edited_time`
- expose the filter through syncer and CLI entrypoint
- test filtering logic
- document the sync process with a mermaid diagram

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_683f5a2ae2608324a1bc74982cd5653d