### PR TITLE
Add support for verbose and non-verbose logging in sync process

### DIFF
--- a/.github/workflows/sync_notion_to_google.yml
+++ b/.github/workflows/sync_notion_to_google.yml
@@ -137,7 +137,7 @@ jobs:
         shell: bash
         run: |
           export TOKEN_PATH="${{ github.workspace }}/token.json"
-          poetry run python main.py
+          poetry run python main.py --no-verbose
         working-directory: ${{ github.workspace }}
         env:
           NOTION_API: ${{ secrets.NOTION_API }}

--- a/main.py
+++ b/main.py
@@ -1,9 +1,28 @@
+import argparse
 import os
 from datetime import datetime
 
 from services.sync_notion_google_task.main import NotionToGoogleTaskSyncer
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Sync Notion pages to Google Tasks and vice versa."
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        default=True,
+        help="Enable verbose logging (default: True). Use --no-verbose to disable.",
+    )
+    parser.add_argument(
+        "--no-verbose",
+        dest="verbose",
+        action="store_false",
+        help="Disable verbose logging to hide sensitive information.",
+    )
+
+    args = parser.parse_args()
+
     notion_api_key = os.getenv("NOTION_API")
     database_id = os.getenv("DATABASE_ID")
     token_path = os.getenv("TOKEN_PATH")
@@ -19,15 +38,9 @@ if __name__ == "__main__":
     assert (
         last_successful_sync
     ), "LAST_SUCCESSFUL_SYNC environment variable is required."
-    last_successful_sync = datetime.fromisoformat(
-        last_successful_sync.replace("Z", "")
-    )
-    assert (
-        free_mobile_user_id
-    ), "FREE_MOBILE_USER_ID environment variable is required."
-    assert (
-        free_mobile_api_key
-    ), "FREE_MOBILE_API_KEY environment variable is required."
+    last_successful_sync = datetime.fromisoformat(last_successful_sync.replace("Z", ""))
+    assert free_mobile_user_id, "FREE_MOBILE_USER_ID environment variable is required."
+    assert free_mobile_api_key, "FREE_MOBILE_API_KEY environment variable is required."
 
     syncer = NotionToGoogleTaskSyncer(
         notion_api_key=notion_api_key,
@@ -36,8 +49,7 @@ if __name__ == "__main__":
         token_path=token_path,
         sms_user=free_mobile_user_id,
         sms_password=free_mobile_api_key,
+        verbose=args.verbose,
     )
     syncer.sync_pages_to_google_tasks()
-    syncer.sync_google_tasks_to_notion(
-        last_successful_sync=last_successful_sync
-    )
+    syncer.sync_google_tasks_to_notion(last_successful_sync=last_successful_sync)


### PR DESCRIPTION
This pull request introduces a verbose logging feature to the Notion-to-Google Tasks synchronization tool, allowing users to toggle detailed logs for debugging or suppress sensitive information. It also includes code cleanup and minor refactoring for clarity and maintainability.

### Logging Enhancements:
* Added an `--verbose` flag to the CLI in `main.py` to toggle detailed logging. By default, verbose logging is enabled, with an option to disable it using `--no-verbose`.
* Introduced a `verbose` parameter to the `NotionToGoogleTaskSyncer` class in `services/sync_notion_google_task/main.py`, along with helper methods `_verbose_print` and `_safe_truncate` for conditional logging and safe text truncation.
* Updated logging in multiple methods (e.g., `sync_pages_to_google_tasks`, `build_task_description`, and others) to conditionally display detailed or minimal messages based on the `verbose` flag. [[1]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2R81-R110) [[2]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2R128-R151) [[3]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2R327-R330) [[4]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2R374-R390) [[5]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2R407-R412) [[6]](diffhunk://#diff-ca3291ce30ba1de4e7c6d1b01581005f2532cba798ef777740f965964fb2c3e2R490-R495)

### Code Cleanup and Refactoring:
* Simplified environment variable assertions in `main.py` for better readability.
* Refactored task title construction in `sync_pages_to_google_tasks` to improve clarity and reuse.
* Renamed variables and adjusted formatting in `build_task_description` for consistency.

### Workflow Update:
* Modified the GitHub Actions workflow in `.github/workflows/sync_notion_to_google.yml` to include the `--no-verbose` flag during execution, ensuring sensitive logs are suppressed in CI/CD runs.