### PR TITLE
fix : Enhance sync functionality for single Notion page ID

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--page-id",
-        type=int,
+        type=str,
         help="ID of the Notion page to sync. When provided, automatically sets mode to 'single'.",
     )
     parser.add_argument(
@@ -91,9 +91,8 @@ if __name__ == "__main__":
         # Process a single page
         print(f"Processing single Notion page (ID: {args.page_id})")
         # Use a list with the specific page ID
-        query_page_ids = [args.page_id]
         syncer.sync_pages_to_google_tasks(
-            query_page_ids=query_page_ids,
+            single_page_id=args.page_id,
         )
     else:
         # Full synchronization

--- a/services/notion/src/notion_client.py
+++ b/services/notion/src/notion_client.py
@@ -91,6 +91,27 @@ class NotionClient:
         except FileNotFoundError as e:
             print(f"[red]Error loading query payload: {e}[/red]")
             return None
+        
+    def get_page_by_id(self, page_id: str) -> Optional[Dict]:
+        """
+        Fetches a single page from Notion by its ID.
+
+        Args:
+            page_id (str): The unique ID of the page to fetch (without hyphens).
+
+        Returns:
+            Optional[Dict]: The JSON response from the Notion API if successful; None otherwise.
+        """
+        url = f"https://api.notion.com/v1/pages/{page_id.replace('-', '')}"
+
+        try:
+            response = requests.get(url, headers=self.headers)
+            response.raise_for_status()
+            return response.json()
+
+        except requests.exceptions.RequestException as e:
+            print(f"[red]Error fetching page {page_id}: {e}[/red]")
+            return None
 
     def fetch_parent_page_names(
         self, parent_page_ids: Set[str]

--- a/services/sync_notion_google_task/main.py
+++ b/services/sync_notion_google_task/main.py
@@ -72,8 +72,7 @@ class NotionToGoogleTaskSyncer:
     # Method to sync Notion pages to Google Tasks
 
     def sync_pages_to_google_tasks(
-        self, last_successful_sync: Optional[datetime] = None,
-        query_page_ids: Optional[List[int]] = None
+        self, last_successful_sync: Optional[datetime] = None, single_page_id: Optional[str] = None
     ):
         """
         Synchronizes Notion pages to Google Tasks with a progress bar that remains at the top.
@@ -81,12 +80,18 @@ class NotionToGoogleTaskSyncer:
         Args:
             last_successful_sync (Optional[datetime]): If provided, only sync pages
                                                       modified since this timestamp.
-            query_page_ids (Optional[List[int]]): If provided, only sync the specified page IDs.
+            single_page_id (Optional[int]): If provided, only sync the specified page ID.
         """
-        notion_pages = self.notion_client.get_filtered_sorted_database(
-            query_page_ids=query_page_ids if query_page_ids else [-1],
-            last_successful_sync=last_successful_sync
-        )
+        if not single_page_id:
+            notion_pages = self.notion_client.get_filtered_sorted_database(
+                last_successful_sync=last_successful_sync
+            )
+        else:
+            single_page = self.notion_client.get_page_by_id(single_page_id)
+            if single_page:
+                notion_pages = {"results": [single_page]}
+            else:
+                notion_pages = None
         if not notion_pages:
             print("[red]No pages retrieved from Notion.[/red]")
             return


### PR DESCRIPTION
Update the synchronization process to support fetching a single Notion page by its ID, improving the efficiency of page retrieval and synchronization.